### PR TITLE
Ajusta mensajes NCR para descuento 25%

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
@@ -1,0 +1,93 @@
+package com.comerzzia.ametller.pos.ncr.actions.sale;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import com.comerzzia.ametller.pos.ncr.ticket.AmetllerScoTicketManager;
+import com.comerzzia.pos.ncr.actions.sale.ItemsManager;
+import com.comerzzia.pos.ncr.messages.ItemSold;
+import com.comerzzia.pos.services.ticket.lineas.LineaTicket;
+
+@Lazy(false)
+@Service
+@Primary
+public class AmetllerItemsManager extends ItemsManager {
+
+    private static final String DESCRIPCION_DESCUENTO_25 = "Descuento del 25% aplicado";
+
+    @Override
+    protected ItemSold lineaTicketToItemSold(LineaTicket linea) {
+        ItemSold itemSold = super.lineaTicketToItemSold(linea);
+
+        if (!(ticketManager instanceof AmetllerScoTicketManager)) {
+            return itemSold;
+        }
+
+        AmetllerScoTicketManager ametllerScoTicketManager = (AmetllerScoTicketManager) ticketManager;
+
+        if (!ametllerScoTicketManager.isLineaConDescuento25(linea)) {
+            return itemSold;
+        }
+
+        BigDecimal precioConDto = linea.getPrecioTotalConDto();
+        if (precioConDto != null) {
+            itemSold.setFieldIntValue(ItemSold.Price, precioConDto);
+        }
+
+        BigDecimal importeConDto = linea.getImporteTotalConDto();
+        if (importeConDto != null) {
+            itemSold.setFieldIntValue(ItemSold.ExtendedPrice, importeConDto);
+        }
+
+        ItemSold discount = itemSold.getDiscountApplied();
+        if (discount == null) {
+            return itemSold;
+        }
+
+        BigDecimal importeSinDto = linea.getImporteTotalSinDto();
+        BigDecimal descuentoCalculado = BigDecimal.ZERO;
+
+        if (importeSinDto != null && importeConDto != null) {
+            descuentoCalculado = importeSinDto.subtract(importeConDto);
+        }
+
+        if ((descuentoCalculado == null || descuentoCalculado.compareTo(BigDecimal.ZERO) <= 0)
+                && linea.getImporteTotalPromociones() != null) {
+            descuentoCalculado = linea.getImporteTotalPromociones();
+        }
+
+        if (descuentoCalculado == null) {
+            return itemSold;
+        }
+
+        descuentoCalculado = descuentoCalculado.setScale(2, RoundingMode.HALF_UP);
+
+        if (descuentoCalculado.compareTo(BigDecimal.ZERO) <= 0) {
+            return itemSold;
+        }
+
+        if (importeConDto == null && importeSinDto != null) {
+            importeConDto = importeSinDto.subtract(descuentoCalculado);
+        }
+
+        if (importeConDto != null) {
+            discount.setFieldIntValue(ItemSold.Price, importeConDto);
+        }
+
+        discount.setFieldValue(ItemSold.ItemNumber,
+                String.valueOf(linea.getIdLinea() + PROMOTIONS_FIRST_ITEM_ID));
+        discount.setFieldIntValue(ItemSold.DiscountAmount, descuentoCalculado);
+        discount.setFieldValue(ItemSold.AssociatedItemNumber, String.valueOf(linea.getIdLinea()));
+        discount.setFieldValue(ItemSold.RewardLocation, "3");
+        discount.setFieldValue(ItemSold.ShowRewardPoints, "1");
+        discount.setFieldValue(ItemSold.DiscountDescription, DESCRIPCION_DESCUENTO_25);
+
+        discount.setFieldValue(ItemSold.Description, DESCRIPCION_DESCUENTO_25);
+
+        return itemSold;
+    }
+}

--- a/src/main/java/com/comerzzia/ametller/pos/ncr/ticket/AmetllerScoTicketManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/ticket/AmetllerScoTicketManager.java
@@ -1,6 +1,8 @@
 package com.comerzzia.ametller.pos.ncr.ticket;
 
 import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -14,10 +16,28 @@ import com.comerzzia.pos.services.ticket.lineas.LineaTicketAbstract;
 public class AmetllerScoTicketManager extends ScoTicketManager {
 
     private static final BigDecimal DESCUENTO25 = new BigDecimal("25.00");
+    private final Set<Integer> lineasConDescuento25 = new HashSet<>();
     private boolean descuento25Activo = false;
 
     public void setDescuento25Activo(boolean activo) {
         this.descuento25Activo = activo;
+    }
+
+    public boolean isLineaConDescuento25(LineaTicket linea) {
+        return linea != null && lineasConDescuento25.contains(linea.getIdLinea());
+    }
+
+    @Override
+    public void initSession() {
+        super.initSession();
+        lineasConDescuento25.clear();
+        descuento25Activo = false;
+    }
+
+    @Override
+    public void ticketInitilize() {
+        super.ticketInitilize();
+        lineasConDescuento25.clear();
     }
 
     @Override
@@ -25,8 +45,15 @@ public class AmetllerScoTicketManager extends ScoTicketManager {
         LineaTicket added = super.addLineToTicket(linea);
         if (descuento25Activo && added != null) {
             added.setDescuentoManual(DESCUENTO25);
+            lineasConDescuento25.add(added.getIdLinea());
             recalculateTicket();
         }
         return added;
+    }
+
+    @Override
+    public void deleteTicketLine(Integer idLinea) {
+        super.deleteTicketLine(idLinea);
+        lineasConDescuento25.remove(idLinea);
     }
 }


### PR DESCRIPTION
## Summary
- Track ticket lines con descuento del 25% en el gestor SCO para poder identificar el descuento manual aplicado.
- Generar mensajes ItemSold con el precio final y el detalle de descuento del 25% para las líneas marcadas.

## Testing
- mvn -q -DskipTests package *(failed: bloqueado al resolver maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68c91c5e7b40832bbfccc3ba1df1d6a0