### PR TITLE
Corrige importes y mensaje de descuento 25%

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
@@ -1,0 +1,128 @@
+package com.comerzzia.ametller.pos.ncr.actions.sale;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import com.comerzzia.ametller.pos.ncr.ticket.AmetllerScoTicketManager;
+import com.comerzzia.pos.ncr.actions.sale.ItemsManager;
+import com.comerzzia.pos.ncr.messages.ItemSold;
+import com.comerzzia.pos.services.ticket.lineas.LineaTicket;
+
+@Lazy(false)
+@Service
+@Primary
+public class AmetllerItemsManager extends ItemsManager {
+
+    private static final String DESCRIPCION_DESCUENTO_25 = "Descuento del 25% aplicado";
+    private static final BigDecimal FACTOR_PRECIO_DESCUENTO = new BigDecimal("0.75");
+    private static final BigDecimal PORCENTAJE_DESCUENTO = new BigDecimal("0.25");
+
+    @Override
+    protected ItemSold lineaTicketToItemSold(LineaTicket linea) {
+        ItemSold itemSold = super.lineaTicketToItemSold(linea);
+
+        if (!(ticketManager instanceof AmetllerScoTicketManager)) {
+            return itemSold;
+        }
+
+        AmetllerScoTicketManager ametllerScoTicketManager = (AmetllerScoTicketManager) ticketManager;
+
+        if (!ametllerScoTicketManager.isLineaConDescuento25(linea)) {
+            return itemSold;
+        }
+
+        BigDecimal cantidad = linea.getCantidad();
+        if (cantidad == null || cantidad.compareTo(BigDecimal.ZERO) <= 0) {
+            cantidad = BigDecimal.ONE;
+        }
+
+        BigDecimal importeSinDto = escalaDosDecimales(linea.getImporteTotalSinDto());
+        BigDecimal importeConDto = escalaDosDecimales(linea.getImporteTotalConDto());
+
+        if (importeConDto == null && importeSinDto != null) {
+            importeConDto = importeSinDto.multiply(FACTOR_PRECIO_DESCUENTO).setScale(2, RoundingMode.HALF_UP);
+        }
+
+        BigDecimal precioConDto = escalaDosDecimales(linea.getPrecioTotalConDto());
+
+        if (precioConDto == null) {
+            if (importeConDto != null && cantidad.compareTo(BigDecimal.ZERO) > 0) {
+                precioConDto = importeConDto.divide(cantidad, 2, RoundingMode.HALF_UP);
+            } else if (importeSinDto != null && cantidad.compareTo(BigDecimal.ZERO) > 0) {
+                precioConDto = importeSinDto.divide(cantidad, 2, RoundingMode.HALF_UP).multiply(FACTOR_PRECIO_DESCUENTO)
+                        .setScale(2, RoundingMode.HALF_UP);
+            }
+        }
+
+        if (precioConDto != null) {
+            itemSold.setFieldIntValue(ItemSold.Price, precioConDto);
+        }
+
+        if (importeConDto != null) {
+            itemSold.setFieldIntValue(ItemSold.ExtendedPrice, importeConDto);
+        }
+
+        ItemSold discount = itemSold.getDiscountApplied();
+        if (discount == null) {
+            return itemSold;
+        }
+
+        BigDecimal descuentoCalculado = null;
+
+        if (importeSinDto != null && importeConDto != null) {
+            descuentoCalculado = importeSinDto.subtract(importeConDto);
+        }
+
+        if ((descuentoCalculado == null || descuentoCalculado.compareTo(BigDecimal.ZERO) <= 0)
+                && precioConDto != null) {
+            BigDecimal precioSinDto = escalaDosDecimales(linea.getPrecioTotalSinDto());
+            if (precioSinDto != null) {
+                descuentoCalculado = precioSinDto.subtract(precioConDto).multiply(cantidad).setScale(2,
+                        RoundingMode.HALF_UP);
+            }
+        }
+
+        if ((descuentoCalculado == null || descuentoCalculado.compareTo(BigDecimal.ZERO) <= 0)
+                && linea.getImporteTotalPromociones() != null) {
+            descuentoCalculado = escalaDosDecimales(linea.getImporteTotalPromociones());
+        }
+
+        if ((descuentoCalculado == null || descuentoCalculado.compareTo(BigDecimal.ZERO) <= 0) && importeSinDto != null) {
+            descuentoCalculado = importeSinDto.multiply(PORCENTAJE_DESCUENTO).setScale(2, RoundingMode.HALF_UP);
+        }
+
+        if (descuentoCalculado == null || descuentoCalculado.compareTo(BigDecimal.ZERO) <= 0) {
+            return itemSold;
+        }
+
+        if (importeConDto == null && importeSinDto != null) {
+            importeConDto = importeSinDto.subtract(descuentoCalculado).setScale(2, RoundingMode.HALF_UP);
+        }
+
+        if (importeConDto != null) {
+            discount.setFieldIntValue(ItemSold.Price, importeConDto);
+        }
+
+        discount.setFieldValue(ItemSold.ItemNumber,
+                String.valueOf(linea.getIdLinea() + PROMOTIONS_FIRST_ITEM_ID));
+        discount.setFieldIntValue(ItemSold.DiscountAmount, descuentoCalculado.setScale(2, RoundingMode.HALF_UP));
+        discount.setFieldValue(ItemSold.AssociatedItemNumber, String.valueOf(linea.getIdLinea()));
+        discount.setFieldValue(ItemSold.RewardLocation, "3");
+        discount.setFieldValue(ItemSold.ShowRewardPoints, "1");
+        discount.setFieldValue(ItemSold.DiscountDescription, DESCRIPCION_DESCUENTO_25);
+        discount.setFieldValue(ItemSold.Description, DESCRIPCION_DESCUENTO_25);
+
+        return itemSold;
+    }
+
+    private BigDecimal escalaDosDecimales(BigDecimal valor) {
+        if (valor == null) {
+            return null;
+        }
+        return valor.setScale(2, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/java/com/comerzzia/ametller/pos/ncr/ticket/AmetllerScoTicketManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/ticket/AmetllerScoTicketManager.java
@@ -1,6 +1,8 @@
 package com.comerzzia.ametller.pos.ncr.ticket;
 
 import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -14,10 +16,28 @@ import com.comerzzia.pos.services.ticket.lineas.LineaTicketAbstract;
 public class AmetllerScoTicketManager extends ScoTicketManager {
 
     private static final BigDecimal DESCUENTO25 = new BigDecimal("25.00");
+    private final Set<Integer> lineasConDescuento25 = new HashSet<>();
     private boolean descuento25Activo = false;
 
     public void setDescuento25Activo(boolean activo) {
         this.descuento25Activo = activo;
+    }
+
+    public boolean isLineaConDescuento25(LineaTicket linea) {
+        return linea != null && lineasConDescuento25.contains(linea.getIdLinea());
+    }
+
+    @Override
+    public void initSession() {
+        super.initSession();
+        lineasConDescuento25.clear();
+        descuento25Activo = false;
+    }
+
+    @Override
+    public void ticketInitilize() {
+        super.ticketInitilize();
+        lineasConDescuento25.clear();
     }
 
     @Override
@@ -25,8 +45,16 @@ public class AmetllerScoTicketManager extends ScoTicketManager {
         LineaTicket added = super.addLineToTicket(linea);
         if (descuento25Activo && added != null) {
             added.setDescuentoManual(DESCUENTO25);
+            added.recalcularImporteFinal();
+            lineasConDescuento25.add(added.getIdLinea());
             recalculateTicket();
         }
         return added;
+    }
+
+    @Override
+    public void deleteTicketLine(Integer idLinea) {
+        super.deleteTicketLine(idLinea);
+        lineasConDescuento25.remove(idLinea);
     }
 }


### PR DESCRIPTION
## Summary
- Calcula los importes finales de líneas con descuento manual del 25% para que el mensaje ItemSold envíe el precio rebajado y el total correcto.
- Genera el mensaje asociado al descuento con la descripción "Descuento del 25% aplicado" y el importe ahorrado en céntimos.
- Recalcula la línea del ticket tras aplicar el descuento manual para actualizar importes antes de enviar los mensajes.

## Testing
- mvn -q -DskipTests package *(falla: repositorio maven-resources-plugin bloqueado en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68c91c5e7b40832bbfccc3ba1df1d6a0