### PR TITLE
Show 25% discount lines for discounted items

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
@@ -1,0 +1,48 @@
+package com.comerzzia.ametller.pos.ncr.actions.sale;
+
+import java.math.BigDecimal;
+
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import com.comerzzia.ametller.pos.ncr.ticket.AmetllerScoTicketManager;
+import com.comerzzia.pos.ncr.actions.sale.ItemsManager;
+import com.comerzzia.pos.ncr.messages.ItemSold;
+import com.comerzzia.pos.services.ticket.lineas.LineaTicket;
+import com.comerzzia.pos.util.bigdecimal.BigDecimalUtil;
+
+@Lazy(false)
+@Service
+@Primary
+@DependsOn("itemsManager")
+public class AmetllerItemsManager extends ItemsManager {
+
+    private static final String DESCUENTO_25_DESCRIPTION = "Descuento del 25% aplicado";
+
+    @Override
+    protected ItemSold lineaTicketToItemSold(LineaTicket linea) {
+        ItemSold itemSold = super.lineaTicketToItemSold(linea);
+
+        if (linea != null && itemSold != null && ticketManager instanceof AmetllerScoTicketManager) {
+            AmetllerScoTicketManager ametllerScoTicketManager = (AmetllerScoTicketManager) ticketManager;
+            if (ametllerScoTicketManager.hasDescuento25Aplicado(linea)) {
+                BigDecimal importeSinDto = linea.getImporteTotalSinDto();
+                BigDecimal importeConDto = linea.getImporteTotalConDto();
+
+                if (importeSinDto != null && importeConDto != null) {
+                    BigDecimal ahorro = importeSinDto.subtract(importeConDto);
+
+                    if (BigDecimalUtil.isMayorACero(ahorro)) {
+                        itemSold.setDiscount(importeConDto, ahorro, DESCUENTO_25_DESCRIPTION);
+                    } else {
+                        ametllerScoTicketManager.removeDescuento25(linea.getIdLinea());
+                    }
+                }
+            }
+        }
+
+        return itemSold;
+    }
+}

--- a/src/main/java/com/comerzzia/ametller/pos/ncr/ticket/AmetllerScoTicketManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/ticket/AmetllerScoTicketManager.java
@@ -1,6 +1,8 @@
 package com.comerzzia.ametller.pos.ncr.ticket;
 
 import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -15,9 +17,20 @@ public class AmetllerScoTicketManager extends ScoTicketManager {
 
     private static final BigDecimal DESCUENTO25 = new BigDecimal("25.00");
     private boolean descuento25Activo = false;
+    private final Set<Integer> lineasConDescuento25 = new HashSet<>();
 
     public void setDescuento25Activo(boolean activo) {
         this.descuento25Activo = activo;
+    }
+
+    public boolean hasDescuento25Aplicado(LineaTicket linea) {
+        return linea != null && lineasConDescuento25.contains(linea.getIdLinea());
+    }
+
+    public void removeDescuento25(Integer idLinea) {
+        if (idLinea != null) {
+            lineasConDescuento25.remove(idLinea);
+        }
     }
 
     @Override
@@ -26,7 +39,28 @@ public class AmetllerScoTicketManager extends ScoTicketManager {
         if (descuento25Activo && added != null) {
             added.setDescuentoManual(DESCUENTO25);
             recalculateTicket();
+            if (added.getIdLinea() != null) {
+                lineasConDescuento25.add(added.getIdLinea());
+            }
         }
         return added;
+    }
+
+    @Override
+    public void deleteTicketLine(Integer idLinea) {
+        super.deleteTicketLine(idLinea);
+        removeDescuento25(idLinea);
+    }
+
+    @Override
+    public void ticketInitilize() {
+        super.ticketInitilize();
+        lineasConDescuento25.clear();
+    }
+
+    @Override
+    public void initSession() {
+        super.initSession();
+        lineasConDescuento25.clear();
     }
 }


### PR DESCRIPTION
## Summary
- track lines discounted with the 25% button in the custom SCO ticket manager
- override the ItemsManager mapping to emit a discount line with "Descuento del 25% aplicado"

## Testing
- mvn -q -DskipTests package *(fails: Blocked mirror for repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68c947afab34832b9557722bd1db3b20