### PR TITLE
Ensure gift card pay manager is registered for tender handling

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
@@ -21,6 +21,7 @@ import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
@@ -50,6 +51,7 @@ import com.comerzzia.pos.ncr.messages.TenderException;
 import com.comerzzia.pos.ncr.messages.TenderAccepted;
 import com.comerzzia.pos.persistence.mediosPagos.MedioPagoBean;
 
+@Lazy(false)
 @Service
 @Primary
 @DependsOn("payManager")


### PR DESCRIPTION
## Summary
- ensure the custom Ametller pay manager runs its `@PostConstruct` registration against the NCR controller
- depend on the base pay manager bean so the custom handler overrides the default action manager mapping

## Testing
- `mvn -q -DskipTests package` *(fails: Blocked mirror for http://repo.comerzzia.com/artifactory/comerzzia/)*

------
https://chatgpt.com/codex/tasks/task_e_68cad2d56064832b9fd244e2fda519ed