### PR TITLE
Handle unknown NCR messages

### DIFF
--- a/src/main/java/com/comerzzia/pos/ncr/messages/NCRMessageFactory.java
+++ b/src/main/java/com/comerzzia/pos/ncr/messages/NCRMessageFactory.java
@@ -15,19 +15,37 @@ public class NCRMessageFactory {
    private static final Logger log = Logger.getLogger(NCRMessageFactory.class);
    
    public static BasicNCRMessage createFromString(String message) {
-	   Document doc = convertStringToXMLDocument(message);
-	   
-	   Element root = doc.getDocumentElement();
-	   
-	   String messageName = root.getAttribute("name");
+           Document doc = convertStringToXMLDocument(message);
 
-	   BasicNCRMessage ncrMessage = newMessage(messageName);
-	   
-	   if (ncrMessage == null) return null;
-	   
-	   ncrMessage.readXml(doc);
-	   
-	   return ncrMessage;
+           if (doc == null) {
+                   log.warn("no se ha entendido el mensaje enviado por ncr: " + message);
+                   return new UnknownMessage("UnknownMessage", message);
+           }
+
+           Element root = doc.getDocumentElement();
+
+           if (root == null) {
+                   log.warn("no se ha entendido el mensaje enviado por ncr: " + message);
+                   return new UnknownMessage("UnknownMessage", message);
+           }
+
+           String messageName = root.getAttribute("name");
+
+           if (messageName == null || messageName.isEmpty()) {
+                   log.warn("no se ha entendido el mensaje enviado por ncr: " + message);
+                   return new UnknownMessage("UnknownMessage", message);
+           }
+
+           BasicNCRMessage ncrMessage = newMessage(messageName);
+
+           if (ncrMessage == null) {
+                   log.warn("no se ha entendido el mensaje enviado por ncr: " + message);
+                   return new UnknownMessage(messageName, message);
+           }
+
+           ncrMessage.readXml(doc);
+
+           return ncrMessage;
    }
    
    private static Document convertStringToXMLDocument(String xmlString) {

--- a/src/main/java/com/comerzzia/pos/ncr/messages/UnknownMessage.java
+++ b/src/main/java/com/comerzzia/pos/ncr/messages/UnknownMessage.java
@@ -1,0 +1,30 @@
+package com.comerzzia.pos.ncr.messages;
+
+/**
+ * Message returned by the factory when the incoming payload cannot be mapped to any
+ * known NCR message implementation. The raw XML is kept so that it can still be
+ * logged or displayed to assist with troubleshooting.
+ */
+public class UnknownMessage extends BasicNCRMessage {
+
+    private final String rawMessage;
+
+    public UnknownMessage(String messageName, String rawMessage) {
+        this.rawMessage = rawMessage;
+
+        if (messageName != null && !messageName.isEmpty()) {
+            setName(messageName);
+        } else {
+            setName(this.getClass().getSimpleName());
+        }
+    }
+
+    public String getRawMessage() {
+        return rawMessage;
+    }
+
+    @Override
+    public String toString() {
+        return rawMessage != null ? rawMessage : super.toString();
+    }
+}


### PR DESCRIPTION
## Summary
- add an `UnknownMessage` representation that keeps the raw NCR payload so it can still be displayed when a message type is not recognised
- update the message factory to log "no se ha entendido el mensaje enviado por ncr" and return the fallback message whenever parsing or instantiation fails

## Testing
- `mvn -q -DskipTests package` *(fails: blocked from reaching the configured Maven repository in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc23a0c9f8832b8707ca32a28995fa