### PR TITLE
Detect discount changes via description comparison

### DIFF
--- a/src/main/java/com/comerzzia/pos/ncr/actions/sale/ItemsManager.java
+++ b/src/main/java/com/comerzzia/pos/ncr/actions/sale/ItemsManager.java
@@ -490,13 +490,16 @@ public class ItemsManager implements ActionManager {
 			  
 			  String actualDiscount = currentItemSold.getDiscountApplied().getFieldValue(ItemSold.DiscountAmount);
 			  String newDiscount = newItemSold.getDiscountApplied().getFieldValue(ItemSold.DiscountAmount);
+			  String actualDiscountDescription = currentItemSold.getDiscountApplied().getFieldValue(ItemSold.Description);
+			  String newDiscountDescription = newItemSold.getDiscountApplied().getFieldValue(ItemSold.Description);
 			  
 //			  log.debug("Updating line " + ticketLine.getIdLinea());
 //			  log.debug("actualDiscount " + actualDiscount);
 //			  log.debug("newDiscount " + newDiscount);
 			  
 			  // compare cached values & send changes				
-			  if (!StringUtils.equals(actualDiscount, newDiscount)) {
+			  if (!StringUtils.equals(actualDiscount, newDiscount)
+			  				|| !StringUtils.equals(actualDiscountDescription, newDiscountDescription)) {
 				  log.debug("Updating line " + ticketLine.getIdLinea());
 				  
 				  if (!StringUtils.equals(actualDiscount, "0") && StringUtils.equals(newDiscount, "0")) {

--- a/src/main/java/com/comerzzia/pos/ncr/messages/ItemSold.java
+++ b/src/main/java/com/comerzzia/pos/ncr/messages/ItemSold.java
@@ -72,9 +72,9 @@ public class ItemSold extends BasicNCRMessage {
 //		   discount.setFieldValue(ItemSold.DiscountDescription, description);						
 //		}
 		
-		discount.setFieldValue(ItemSold.ItemNumber, getFieldValue(ItemSold.ItemNumber));
-		discount.setFieldIntValue(ItemSold.Price, importeLineaConDescuento);
-		discount.setFieldValue(ItemSold.UPC, getFieldValue(ItemSold.UPC));
+                discount.setFieldValue(ItemSold.ItemNumber, getFieldValue(ItemSold.ItemNumber));
+                discount.setFieldIntValue(ItemSold.Price, importeLineaConDescuento);
+                discount.setFieldValue(ItemSold.UPC, getFieldValue(ItemSold.UPC));
 
 		if (importeLineaConDescuento.compareTo(BigDecimal.ZERO) == 0) {
 //   		   discount.setFieldValue(ItemSold.Description, getFieldValue(ItemSold.Description));


### PR DESCRIPTION
## Summary
- compare cached and recalculated discount descriptions to ensure loyalty promotions resend the updated line item

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3d9c8adec832b9d75db19d81cc57d